### PR TITLE
Testing more via github action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,9 +1,13 @@
 name: Godot testing
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The github action currently runs the unit tests when a pull request is made/updated, but this PR makes it run every commit on `main` and also a manually-triggered option.