### PR TITLE
refactor: Rename region from "Initialization" to "init" for consistency.

### DIFF
--- a/scripts/multiplayer/replication/handshake_spawner.gd
+++ b/scripts/multiplayer/replication/handshake_spawner.gd
@@ -21,7 +21,7 @@ var _spawned: Dictionary[String, SpawnRequest] = {}
 
 var _handshake: HandshakeRetryTimer
 
-#region Initialization
+#region init
 
 func _enter_tree() -> void:
 	assert(spawn_path, "HandshakeSpawner must have a spawn_path")


### PR DESCRIPTION
I was reading the code and noticed that this is the only file where the "init" region isn't labelled as "init", so I changed it to match the rest of the codebase.