### PR TITLE
Consolidate network setup for tests

### DIFF
--- a/test/__setup__/base_network_gut_test.gd
+++ b/test/__setup__/base_network_gut_test.gd
@@ -1,0 +1,51 @@
+class_name BaseNetworkGutTest
+extends GutTest
+
+## This base class is responsible for setting up a server & client network
+## environment in the same Scene Tree. This allows us to test multiplayer
+## functionality without needing to run two separate instances of the game.
+
+## The port used for running network tests
+const NETWORK_TEST_PORT: int = 9001
+
+## Add children to this node to run on the server-side
+var _server_node: Node
+
+## Add children to this node to run on the client-side
+var _client_node: Node
+
+func before_all() -> void:
+    # Create parent nodes
+    _server_node = Node.new()
+    add_child(_server_node)
+    _client_node = Node.new()
+    add_child(_client_node)
+
+    # Setup server
+    var server_mp := SceneMultiplayer.new()
+    get_tree().set_multiplayer(server_mp, _server_node.get_path())
+
+    var server_peer = ENetMultiplayerPeer.new()
+    server_peer.create_server(NETWORK_TEST_PORT)
+    _server_node.multiplayer.multiplayer_peer = server_peer
+
+    # Setup client
+    var client_mp := SceneMultiplayer.new()
+    get_tree().set_multiplayer(client_mp, _client_node.get_path())
+
+    var client_peer = ENetMultiplayerPeer.new()
+    client_peer.create_client("127.0.0.1", NETWORK_TEST_PORT)
+    _client_node.multiplayer.multiplayer_peer = client_peer
+
+func after_all() -> void:
+    # Close connections
+    if _client_node and _client_node.multiplayer.multiplayer_peer:
+        _client_node.multiplayer.multiplayer_peer.close()
+    if _server_node and _server_node.multiplayer.multiplayer_peer:
+        _server_node.multiplayer.multiplayer_peer.close()
+
+    # Remove nodes
+    if _client_node:
+        _client_node.queue_free()
+    if _server_node:
+        _server_node.queue_free()

--- a/test/__setup__/base_network_gut_test.gd.uid
+++ b/test/__setup__/base_network_gut_test.gd.uid
@@ -1,0 +1,1 @@
+uid://1l1yhkgl1gie

--- a/test/multiplayer/replication/test_handshake_synchronizer.gd
+++ b/test/multiplayer/replication/test_handshake_synchronizer.gd
@@ -1,59 +1,28 @@
-extends GutTest
-
-# --- Network Setup Variables ---
-var server_node: Node
-var client_node: Node
-var _server_peer: ENetMultiplayerPeer
-var _client_peer: ENetMultiplayerPeer
-
-const PORT = 8916 # Use a different port just in case
-const LOCALHOST = "127.0.0.1"
+extends BaseNetworkGutTest
 
 func before_each():
-	# 1. Create the root nodes for each "peer"
-	server_node = Node.new()
-	server_node.name = "ServerRoot"
-	add_child(server_node)
-	
-	client_node = Node.new()
-	client_node.name = "ClientRoot"
-	add_child(client_node)
-
-	# 2. Setup Server Network
-	_server_peer = ENetMultiplayerPeer.new()
-	_server_peer.create_server(PORT)
-	var server_mp = SceneMultiplayer.new()
-	server_mp.multiplayer_peer = _server_peer
-	get_tree().set_multiplayer(server_mp, server_node.get_path())
-
-	# 3. Setup Client Network
-	_client_peer = ENetMultiplayerPeer.new()
-	_client_peer.create_client(LOCALHOST, PORT)
-	var client_mp = SceneMultiplayer.new()
-	client_mp.multiplayer_peer = _client_peer
-	get_tree().set_multiplayer(client_mp, client_node.get_path())
-
-	# 4. Wait for connection
+	# Wait for connection (setup is handled by base class)
 	await wait_seconds(0.1)
 
 func after_each():
-	if _server_peer: _server_peer.close()
-	if _client_peer: _client_peer.close()
-	server_node.free()
-	client_node.free()
+	# Clear test children from the base nodes
+	for child in _server_node.get_children():
+		child.free()
+	for child in _client_node.get_children():
+		child.free()
 
 # --- Tests ---
 
 func test_server_hides_visibility_by_default():
 	var this_sync = HandshakeSynchronizer.new()
-	server_node.add_child(this_sync)
+	_server_node.add_child(this_sync)
 	
 	assert_false(this_sync.public_visibility, "Server should set public_visibility to false on enter_tree")
 	assert_false(this_sync.get_visibility_for(1), "Should not be visible to self initially")
 
 func test_client_creates_retry_timer():
 	var sync = HandshakeSynchronizer.new()
-	client_node.add_child(sync )
+	_client_node.add_child(sync )
 	
 	# Verify internal child
 	var has_timer = false
@@ -68,12 +37,12 @@ func test_handshake_flow_grants_visibility():
 	# 1. Setup Server Side
 	var server_sync = HandshakeSynchronizer.new()
 	server_sync.name = "SyncNode"
-	server_node.add_child(server_sync)
+	_server_node.add_child(server_sync)
 	
 	# 2. Setup Client Side
 	var client_sync = HandshakeSynchronizer.new()
 	client_sync.name = "SyncNode"
-	client_node.add_child(client_sync)
+	_client_node.add_child(client_sync)
 	
 	await wait_seconds(0.1)
 	
@@ -85,7 +54,7 @@ func test_handshake_flow_grants_visibility():
 	await wait_seconds(0.1)
 	
 	# 5. Verify Server State
-	var client_peer_id = server_node.multiplayer.get_peers()[0]
+	var client_peer_id = _server_node.multiplayer.get_peers()[0]
 	assert_true(
 		server_sync.get_visibility_for(client_peer_id),
 		"Server should have granted visibility to the client"


### PR DESCRIPTION
## Summary

While developing my own game, I refactored this code so here's the newer version. Just moved the network setup for running both a server and a client within the same scene tree to a base `BaseNetworkGutTest` class that I can extend to test behavior on both the server and the client side simultaneously.

## The star of the show

```gdscript
class_name BaseNetworkGutTest
extends GutTest

## This base class is responsible for setting up a server & client network
## environment in the same Scene Tree. This allows us to test multiplayer
## functionality without needing to run two separate instances of the game.

## The port used for running network tests
const NETWORK_TEST_PORT: int = 9001

## Add children to this node to run on the server-side
var _server_node: Node

## Add children to this node to run on the client-side
var _client_node: Node

func before_all() -> void:
    # Create parent nodes
    _server_node = Node.new()
    add_child(_server_node)
    _client_node = Node.new()
    add_child(_client_node)

    # Setup server
    var server_mp := SceneMultiplayer.new()
    get_tree().set_multiplayer(server_mp, _server_node.get_path())

    var server_peer = ENetMultiplayerPeer.new()
    server_peer.create_server(NETWORK_TEST_PORT)
    _server_node.multiplayer.multiplayer_peer = server_peer

    # Setup client
    var client_mp := SceneMultiplayer.new()
    get_tree().set_multiplayer(client_mp, _client_node.get_path())

    var client_peer = ENetMultiplayerPeer.new()
    client_peer.create_client("127.0.0.1", NETWORK_TEST_PORT)
    _client_node.multiplayer.multiplayer_peer = client_peer

func after_all() -> void:
    # Close connections
    if _client_node and _client_node.multiplayer.multiplayer_peer:
        _client_node.multiplayer.multiplayer_peer.close()
    if _server_node and _server_node.multiplayer.multiplayer_peer:
        _server_node.multiplayer.multiplayer_peer.close()

    # Remove nodes
    if _client_node:
        _client_node.queue_free()
    if _server_node:
        _server_node.queue_free()

```

The `HandshakeSpawner` and `HandshakeSynchronizer` tests were updated to use these new server and client nodes instead of spinning up their own.

https://github.com/RGonzalezTech/Friendslop-Template/blob/c89c2933a79414a251ec4b8aac71295c992f33e8/test/multiplayer/replication/test_handshake_spawner.gd#L25-L44