### PR TITLE
Simplify the player spawn manager tests, too

### DIFF
--- a/test/__setup__/base_network_gut_test.gd
+++ b/test/__setup__/base_network_gut_test.gd
@@ -1,9 +1,15 @@
 class_name BaseNetworkGutTest
 extends GutTest
 
-## This base class is responsible for setting up a server & client network
-## environment in the same Scene Tree. This allows us to test multiplayer
-## functionality without needing to run two separate instances of the game.
+## This base class is responsible for providing a server & client network
+## container in the same Scene Tree. 
+##
+## [IMPORTANT] Developers are expected to call `setup_server()` and 
+## `setup_client()` manually within their test setup or test methods to 
+## initialize the networking environment.
+## 
+## This allows us to test multiplayer functionality without needing to 
+## run two separate instances of the game.
 
 ## The port used for running network tests
 const NETWORK_TEST_PORT: int = 9001
@@ -15,37 +21,43 @@ var _server_node: Node
 var _client_node: Node
 
 func before_all() -> void:
-    # Create parent nodes
-    _server_node = Node.new()
-    add_child(_server_node)
-    _client_node = Node.new()
-    add_child(_client_node)
+	# Create parent nodes
+	_server_node = Node.new()
+	add_child(_server_node)
+	_client_node = Node.new()
+	add_child(_client_node)
 
-    # Setup server
-    var server_mp := SceneMultiplayer.new()
-    get_tree().set_multiplayer(server_mp, _server_node.get_path())
+func setup_server() -> void:
+	assert(is_instance_valid(_server_node), "Server node must be initialized before calling setup_server.")
+	
+	# Setup server multiplayer
+	var server_mp := SceneMultiplayer.new()
+	get_tree().set_multiplayer(server_mp, _server_node.get_path())
 
-    var server_peer = ENetMultiplayerPeer.new()
-    server_peer.create_server(NETWORK_TEST_PORT)
-    _server_node.multiplayer.multiplayer_peer = server_peer
+	var server_peer = ENetMultiplayerPeer.new()
+	server_peer.create_server(NETWORK_TEST_PORT)
+	_server_node.multiplayer.multiplayer_peer = server_peer
 
-    # Setup client
-    var client_mp := SceneMultiplayer.new()
-    get_tree().set_multiplayer(client_mp, _client_node.get_path())
+func setup_client() -> void:
+	assert(is_instance_valid(_client_node), "Client node must be initialized before calling setup_client.")
+	
+	# Setup client multiplayer
+	var client_mp := SceneMultiplayer.new()
+	get_tree().set_multiplayer(client_mp, _client_node.get_path())
 
-    var client_peer = ENetMultiplayerPeer.new()
-    client_peer.create_client("127.0.0.1", NETWORK_TEST_PORT)
-    _client_node.multiplayer.multiplayer_peer = client_peer
+	var client_peer = ENetMultiplayerPeer.new()
+	client_peer.create_client("127.0.0.1", NETWORK_TEST_PORT)
+	_client_node.multiplayer.multiplayer_peer = client_peer
 
 func after_all() -> void:
-    # Close connections
-    if _client_node and _client_node.multiplayer.multiplayer_peer:
-        _client_node.multiplayer.multiplayer_peer.close()
-    if _server_node and _server_node.multiplayer.multiplayer_peer:
-        _server_node.multiplayer.multiplayer_peer.close()
+	# Close connections
+	if _client_node and _client_node.multiplayer.multiplayer_peer:
+		_client_node.multiplayer.multiplayer_peer.close()
+	if _server_node and _server_node.multiplayer.multiplayer_peer:
+		_server_node.multiplayer.multiplayer_peer.close()
 
-    # Remove nodes
-    if _client_node:
-        _client_node.queue_free()
-    if _server_node:
-        _server_node.queue_free()
+	# Remove nodes
+	if _client_node:
+		_client_node.queue_free()
+	if _server_node:
+		_server_node.queue_free()

--- a/test/multiplayer/replication/test_handshake_spawner.gd
+++ b/test/multiplayer/replication/test_handshake_spawner.gd
@@ -19,6 +19,9 @@ var client_container: Node
 var mock_resource: MockSpawnableResource
 
 func before_each():
+	setup_server()
+	setup_client()
+	
 	# 1. Setup Test Resources & Containers
 	mock_resource = MockSpawnableResource.new()
 	

--- a/test/multiplayer/replication/test_handshake_synchronizer.gd
+++ b/test/multiplayer/replication/test_handshake_synchronizer.gd
@@ -1,7 +1,10 @@
 extends BaseNetworkGutTest
 
 func before_each():
-	# Wait for connection (setup is handled by base class)
+	setup_server()
+	setup_client()
+	
+	# Wait for connection
 	await wait_seconds(0.1)
 
 func after_each():


### PR DESCRIPTION
## Summary

The player spawner tests were kinda hard to read and understand, so I refactored them to leverage the new central `BaseNetworkGutTest` node and made some helper functions to make it easier to read.

## New Change

Must call `setup_server()` or `setup_client()` in tests to initialize the connections on the respective `_server_node` and `_client_node`