### PR TITLE
Speed up awaits in unit tests

### DIFF
--- a/test/multiplayer/player_spawning/test_base_player_spawn_manager.gd
+++ b/test/multiplayer/player_spawning/test_base_player_spawn_manager.gd
@@ -58,7 +58,7 @@ func before_each():
 	_server_node.add_child(_spawn_manager)
 	
 	# Wait for network setup
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 
 func after_each():
 	if is_instance_valid(_spawn_container):
@@ -86,7 +86,7 @@ func test_spawn_player_on_ready_signal():
 	
 	_simulate_player_ready_for_spawn(peer_id, spawn_params)
 	
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	assert_eq(_spawn_container.get_child_count(), 1, "A player should have been spawned in the container")
 	var spawned_node = _spawn_container.get_child(0)
@@ -97,10 +97,10 @@ func test_spawn_player_only_once():
 	var spawn_params = {"pos": Vector2(200, 200), "peer_id": peer_id}
 	
 	_simulate_player_ready_for_spawn(peer_id, spawn_params)
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	_level_root.player_ready_for_gameplay.emit(peer_id)
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	assert_eq(_spawn_container.get_child_count(), 1, "Player should only be spawned once")
 
@@ -108,11 +108,11 @@ func test_player_left_despawns():
 	var peer_id = 789
 	var spawn_params = {"peer_id": peer_id}
 	_simulate_player_ready_for_spawn(peer_id, spawn_params)
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	assert_eq(_spawn_container.get_child_count(), 1, "Player should be spawned initially")
 	
 	LobbyManager.player_left.emit(peer_id)
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	assert_eq(_spawn_container.get_child_count(), 0, "Player should be despawned after leaving")
 
@@ -123,17 +123,17 @@ func test_can_remove_same_peer_id_multiple_times_without_crashing():
 	var spawn_params = {"peer_id": peer_id}
 	
 	_simulate_player_ready_for_spawn(peer_id, spawn_params)
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	var spawned_node = _spawn_container.get_child(0)
 	var spawn_id = spawned_node.get_meta("s_id")
 	
 	_handshake_spawner.despawn_id(spawn_id)
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	assert_eq(_spawn_container.get_child_count(), 0, "Node should be despawned from the scene tree")
 	
 	LobbyManager.player_left.emit(peer_id)
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	assert_eq(_spawn_container.get_child_count(), 0, "Container should remain empty after player_left signal")

--- a/test/multiplayer/player_spawning/test_coll_queue_player_spawn_manager.gd
+++ b/test/multiplayer/player_spawning/test_coll_queue_player_spawn_manager.gd
@@ -7,6 +7,13 @@ func before_all() -> void:
     # Set up as a network server
     setup_server()
 
+    # Speed up the retry timer for this test
+    Engine.time_scale = 2
+
+func after_all() -> void:
+    super ()
+    Engine.time_scale = 1
+
 var mock_network_root: NetworkLevelRoot
 var mock_handshake_spawner: HandshakeSpawner
 

--- a/test/multiplayer/replication/test_handshake_retry_timer.gd
+++ b/test/multiplayer/replication/test_handshake_retry_timer.gd
@@ -2,6 +2,13 @@ extends GutTest
 
 var _timer: HandshakeRetryTimer
 
+func before_all():
+	# Speed up the timer logic
+	Engine.time_scale = 3
+
+func after_all():
+	Engine.time_scale = 1
+
 func before_each():
 	_timer = HandshakeRetryTimer.new()
 	add_child_autofree(_timer)

--- a/test/multiplayer/replication/test_handshake_spawner.gd
+++ b/test/multiplayer/replication/test_handshake_spawner.gd
@@ -47,7 +47,7 @@ func before_each():
 	_client_node.add_child(client_spawner)
 
 	# 3. Wait for connection
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 
 func after_each():
 	# Clear test containers and spawners from the base nodes
@@ -65,7 +65,7 @@ func test_spawn_replicates_to_client():
 	server_spawner.spawn("mock_unit", {"hp": 100})
 	
 	# 2. Wait for RPC
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	# 3. Verify Server side
 	assert_eq(server_container.get_child_count(), 1, "Server should have spawned node")
@@ -81,7 +81,7 @@ func test_spawn_replicates_to_client():
 func test_despawn_replicates_to_client():
 	# Setup: Spawn something first
 	server_spawner.spawn("mock_unit", {})
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	var server_entity = server_container.get_child(0)
 	var s_id = server_entity.get_meta("s_id")
@@ -92,7 +92,7 @@ func test_despawn_replicates_to_client():
 	server_spawner.despawn_id(s_id)
 	
 	# 2. Wait for RPC
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	# 3. Verify
 	assert_eq(client_container.get_child_count(), 0, "Client should have removed node")
@@ -106,7 +106,7 @@ func test_late_join_catchup():
 	# request a replay since the nodes are newly added.
 	
 	# Wait for the catch-up handshake
-	await wait_seconds(0.2)
+	await wait_process_frames(2)
 	
 	assert_eq(client_container.get_child_count(), 1, "Client should receive existing entities via catchup")
 	

--- a/test/multiplayer/replication/test_handshake_synchronizer.gd
+++ b/test/multiplayer/replication/test_handshake_synchronizer.gd
@@ -5,7 +5,7 @@ func before_each():
 	setup_client()
 	
 	# Wait for connection
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 
 func after_each():
 	# Clear test children from the base nodes
@@ -47,14 +47,14 @@ func test_handshake_flow_grants_visibility():
 	client_sync.name = "SyncNode"
 	_client_node.add_child(client_sync)
 	
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	# 3. Trigger handshake manually or wait for timer
 	# We manually trigger to ensure test speed/determinism
 	client_sync._on_sync_requested()
 	
 	# 4. Allow RPCs to travel
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	# 5. Verify Server State
 	var client_peer_id = _server_node.multiplayer.get_peers()[0]

--- a/test/multiplayer/test_lobby_manager.gd
+++ b/test/multiplayer/test_lobby_manager.gd
@@ -36,7 +36,7 @@ func test_reset_lobby_clears_players_and_state():
 	_lobby_manager.reset_lobby()
 	
 	# reset_lobby uses queue_free, so we must wait for it to be processed
-	await wait_seconds(0.1)
+	await wait_process_frames(2)
 	
 	assert_eq(_lobby_manager._lobby_players_container.get_child_count(), 0, "LobbyPlayers container should be empty")
 	assert_eq(_lobby_manager.current_lobby.host_id, 1, "Host ID should reset to 1")
@@ -114,7 +114,7 @@ func test_network_events_spawn_and_remove_players():
 	
 	# Test _on_peer_disconnected
 	_lobby_manager._on_peer_disconnected(peer_id)
-	await wait_seconds(0.1) # queue_free
+	await wait_process_frames(2) # queue_free
 	assert_null(_lobby_manager.get_player(peer_id), "Player node should be removed for disconnected peer")
 
 func test_connection_shutdown_resets_lobby_and_returns_to_menu():


### PR DESCRIPTION
## Summary

The tests should now execute faster since I replaced `await wait_seconds(0.2)` with `await wait_process_frames(2)` so it awaits 2 frames instead of 200 ms or whatever. In cases where we need to _simulate_ 200ms passing, I've increased the `Engine.time_scale` so that those run faster, too.