### PR TITLE
Add `teardown_server()` and `teardown_client()` helpers for Network unit tests

### DIFF
--- a/test/__setup__/base_network_gut_test.gd
+++ b/test/__setup__/base_network_gut_test.gd
@@ -49,12 +49,20 @@ func setup_client() -> void:
 	client_peer.create_client("127.0.0.1", NETWORK_TEST_PORT)
 	_client_node.multiplayer.multiplayer_peer = client_peer
 
-func after_all() -> void:
-	# Close connections
-	if _client_node and _client_node.multiplayer.multiplayer_peer:
-		_client_node.multiplayer.multiplayer_peer.close()
+## If the [member _server_node] is set and has a multiplayer peer, close it.
+func teardown_server() -> void:
 	if _server_node and _server_node.multiplayer.multiplayer_peer:
 		_server_node.multiplayer.multiplayer_peer.close()
+
+## If the [member _client_node] is set and has a multiplayer peer, close it.
+func teardown_client() -> void:
+	if _client_node and _client_node.multiplayer.multiplayer_peer:
+		_client_node.multiplayer.multiplayer_peer.close()
+
+func after_all() -> void:
+	# Close connections
+	teardown_client()
+	teardown_server()
 
 	# Remove nodes
 	if _client_node:

--- a/test/multiplayer/player_spawning/test_base_player_spawn_manager.gd
+++ b/test/multiplayer/player_spawning/test_base_player_spawn_manager.gd
@@ -61,6 +61,7 @@ func before_each():
 	await wait_process_frames(2)
 
 func after_each():
+	teardown_server()
 	if is_instance_valid(_spawn_container):
 		_spawn_container.free()
 	if is_instance_valid(_spawn_manager):

--- a/test/multiplayer/replication/test_handshake_spawner.gd
+++ b/test/multiplayer/replication/test_handshake_spawner.gd
@@ -50,6 +50,8 @@ func before_each():
 	await wait_process_frames(2)
 
 func after_each():
+	teardown_client()
+	teardown_server()
 	# Clear test containers and spawners from the base nodes
 	for child in _server_node.get_children():
 		child.free()

--- a/test/multiplayer/replication/test_handshake_synchronizer.gd
+++ b/test/multiplayer/replication/test_handshake_synchronizer.gd
@@ -8,6 +8,8 @@ func before_each():
 	await wait_process_frames(2)
 
 func after_each():
+	teardown_client()
+	teardown_server()
 	# Clear test children from the base nodes
 	for child in _server_node.get_children():
 		child.free()


### PR DESCRIPTION
## Summary

While adding some network tests, I ran into some issues since I forgot to spin down my network connection after each individual test. Figured I'd make it easier and just make some helpers so that it's an option (rather than _only_ cleaning up the nodes).