### PR TITLE
Removing orphan warning for `BaseNetworkGutTest` tests

### DIFF
--- a/test/__setup__/base_network_gut_test.gd
+++ b/test/__setup__/base_network_gut_test.gd
@@ -66,6 +66,6 @@ func after_all() -> void:
 
 	# Remove nodes
 	if _client_node:
-		_client_node.queue_free()
+		_client_node.free()
 	if _server_node:
-		_server_node.queue_free()
+		_server_node.free()

--- a/test/multiplayer/player_spawning/test_coll_queue_player_spawn_manager.gd
+++ b/test/multiplayer/player_spawning/test_coll_queue_player_spawn_manager.gd
@@ -61,9 +61,9 @@ func before_each() -> void:
     _server_node.add_child(spawn_manager)
 
 func after_each() -> void:
-    mock_network_root.queue_free()
-    mock_handshake_spawner.queue_free()
-    spawn_manager.queue_free()
+    mock_network_root.free()
+    mock_handshake_spawner.free()
+    spawn_manager.free()
 
 #endregion
 


### PR DESCRIPTION
## Summary

We were getting a bunch of orphan warnings because our teardown calls use `queue_free()`

closes #29 